### PR TITLE
Remove calls to deprecated CRM_Utils_Array::value

### DIFF
--- a/CRM/Advancedfundraising/Form/Report/Contribute/AggregateDetails.php
+++ b/CRM/Advancedfundraising/Form/Report/Contribute/AggregateDetails.php
@@ -176,11 +176,11 @@ class CRM_Advancedfundraising_Form_Report_Contribute_AggregateDetails extends CR
     $earliestDate = date('Y-m-d');
     $latestDate = date('Y-m-d', strtotime('50 years ago'));
     foreach ($dateFields as $fieldName => $prefix){
-      $relative = CRM_Utils_Array::value("{$fieldName}_relative", $this->_params);
-      $from     = CRM_Utils_Array::value("{$fieldName}_from", $this->_params);
-      $to       = CRM_Utils_Array::value("{$fieldName}_to", $this->_params);
-      $fromTime = CRM_Utils_Array::value("{$fieldName}_from_time", $this->_params);
-      $toTime   = CRM_Utils_Array::value("{$fieldName}_to_time", $this->_params);
+      $relative = $this->_params["{$fieldName}_relative"] ?? NULL;
+      $from     = $this->_params["{$fieldName}_from"] ?? NULL;
+      $to       = $this->_params["{$fieldName}_to"] ?? NULL;
+      $fromTime = $this->_params["{$fieldName}_from_time"] ?? NULL;
+      $toTime   = $this->_params["{$fieldName}_to_time"] ?? NULL;
       list($from, $to) = CRM_Report_Form::getFromTo($relative, $from, $to,  $fromTime, $toTime);
       $this->_ranges['interval_0'][$prefix . 'from_date'] = DATE('Y-m-d', strtotime($from));
       $this->_ranges['interval_0'][$prefix . 'to_date'] = DATE('Y-m-d', strtotime($to));

--- a/CRM/Advancedfundraising/Form/Report/Contribute/AggregatePledgeDetails.php
+++ b/CRM/Advancedfundraising/Form/Report/Contribute/AggregatePledgeDetails.php
@@ -171,11 +171,11 @@ class CRM_Advancedfundraising_Form_Report_Contribute_AggregatePledgeDetails exte
     $earliestDate = date('Y-m-d');
     $latestDate = date('Y-m-d', strtotime('50 years ago'));
     foreach ($dateFields as $fieldName => $prefix){
-      $relative = CRM_Utils_Array::value("{$fieldName}_relative", $this->_params);
-      $from     = CRM_Utils_Array::value("{$fieldName}_from", $this->_params);
-      $to       = CRM_Utils_Array::value("{$fieldName}_to", $this->_params);
-      $fromTime = CRM_Utils_Array::value("{$fieldName}_from_time", $this->_params);
-      $toTime   = CRM_Utils_Array::value("{$fieldName}_to_time", $this->_params);
+      $relative = $this->_params["{$fieldName}_relative"] ?? NULL;
+      $from     = $this->_params["{$fieldName}_from"] ?? NULL;
+      $to       = $this->_params["{$fieldName}_to"] ?? NULL;
+      $fromTime = $this->_params["{$fieldName}_from_time"] ?? NULL;
+      $toTime   = $this->_params["{$fieldName}_to_time"] ?? NULL;
       list($from, $to) = CRM_Report_Form::getFromTo($relative, $from, $to,  $fromTime, $toTime);
       $this->_ranges['interval_0'][$prefix . 'from_date'] = DATE('Y-m-d', strtotime($from));
       $this->_ranges['interval_0'][$prefix . 'to_date'] = DATE('Y-m-d', strtotime($to));

--- a/CRM/Advancedfundraising/Form/Report/Contribute/KeyNumbers.php
+++ b/CRM/Advancedfundraising/Form/Report/Contribute/KeyNumbers.php
@@ -495,7 +495,7 @@ class CRM_Advancedfundraising_Form_Report_Contribute_KeyNumbers extends CRM_Adva
       $this->_kpis[$this->$year]['lowest_donation__' . strtolower($result->contact_type)] = $result->min;
     }
     $this->_kpis[$this->$year]['highest_donation'] = CRM_Utils_Array::value('highest_donation__', $this->_kpis[$this->$year], 0);
-    $this->_kpis[$this->$year]['lowest_donation'] = CRM_Utils_Array::value('lowest_donation__', $this->_kpis[$this->$year]);
+    $this->_kpis[$this->$year]['lowest_donation'] = $this->_kpis[$this->$year]['lowest_donation__'] ?? NULL;
     }
   }
 

--- a/CRM/Advancedfundraising/Form/Report/OpenFlashChart.php
+++ b/CRM/Advancedfundraising/Form/Report/OpenFlashChart.php
@@ -132,16 +132,16 @@ class chart {
     if (empty($params)) {
       return $chart;
     }
-    $this->values = CRM_Utils_Array::value('values', $params);
+    $this->values = $params['values'] ?? NULL;
     if (! is_array($this->values) || empty($this->values)) {
       return $chart;
     }
-    $this->chartTitle = CRM_Utils_Array::value('title', $params);
+    $this->chartTitle = $params['title'] ?? NULL;
     $this->xlabelAngle = CRM_Utils_Array::value('xlabelAngle', $params, 0);
     $this->createChartElement();
     $this->setChartValues();
     $this->setToolTip(CRM_Utils_Array::value('tip', $params));
-    $this->onClickFunName = CRM_Utils_Array::value('on_click_fun_name', $params);
+    $this->onClickFunName = $params['on_click_fun_name'] ?? NULL;
   }
 
   /**
@@ -219,9 +219,9 @@ class barchart extends chart {
   function __construct($params) {
     parent::__construct($params);
     $this->setYMaxYSteps();
-    $this->xAxisName = CRM_Utils_Array::value('xname', $params);
-    $this->yAxisName = CRM_Utils_Array::value('yname', $params);
-    $this->xlabels = CRM_Utils_Array::value('xlabels', $params);
+    $this->xAxisName = $params['xname'] ?? NULL;
+    $this->yAxisName = $params['yname'] ?? NULL;
+    $this->xlabels = $params['xlabels'] ?? NULL;
     $this->chartTitle = CRM_Utils_Array::value('legend', $params, ts('Bar Chart'));
     // call user define function to handle on click event.
     if ($this->onClickFunName) {

--- a/CRM/Advancedfundraising/Form/Report/ReportBase.php
+++ b/CRM/Advancedfundraising/Form/Report/ReportBase.php
@@ -497,32 +497,32 @@ class CRM_Advancedfundraising_Form_Report_ReportBase extends CRM_Report_Form {
           $clause = NULL;
           if (CRM_Utils_Array::value('type', $field) & CRM_Utils_Type::T_DATE) {
             if (CRM_Utils_Array::value('operatorType', $field) == CRM_Report_Form::OP_MONTH) {
-              $op = CRM_Utils_Array::value("{$fieldName}_op", $this->_params);
-              $value = CRM_Utils_Array::value("{$fieldName}_value", $this->_params);
+              $op = $this->_params["{$fieldName}_op"] ?? NULL;
+              $value = $this->_params["{$fieldName}_value"] ?? NULL;
               if (is_array($value) && !empty($value)) {
                 $clause = "(month({$field['dbAlias']}) $op (" . implode(', ', $value) . '))';
                 $this->whereClauses[$tableName][] = $clause;
               }
             }
             else {
-              $relative = CRM_Utils_Array::value("{$fieldName}_relative", $this->_params);
-              $from     = CRM_Utils_Array::value("{$fieldName}_from", $this->_params);
-              $to       = CRM_Utils_Array::value("{$fieldName}_to", $this->_params);
-              $fromTime = CRM_Utils_Array::value("{$fieldName}_from_time", $this->_params);
-              $toTime   = CRM_Utils_Array::value("{$fieldName}_to_time", $this->_params);
+              $relative = $this->_params["{$fieldName}_relative"] ?? NULL;
+              $from     = $this->_params["{$fieldName}_from"] ?? NULL;
+              $to       = $this->_params["{$fieldName}_to"] ?? NULL;
+              $fromTime = $this->_params["{$fieldName}_from_time"] ?? NULL;
+              $toTime   = $this->_params["{$fieldName}_to_time"] ?? NULL;
               // next line is the changed one
               $clause   = $this->dateClause($field['dbAlias'], $relative, $from, $to, $field, $fromTime, $toTime);
               $this->whereClauses[$tableName][] = $clause;
             }
           }
           else {
-            $op = CRM_Utils_Array::value("{$fieldName}_op", $this->_params);
+            $op = $this->_params["{$fieldName}_op"] ?? NULL;
             if ($op) {
               $clause = $this->whereClause($field,
                 $op,
-                CRM_Utils_Array::value("{$fieldName}_value", $this->_params),
-                CRM_Utils_Array::value("{$fieldName}_min", $this->_params),
-                CRM_Utils_Array::value("{$fieldName}_max", $this->_params)
+                $this->_params["{$fieldName}_value"] ?? NULL,
+                $this->_params["{$fieldName}_min"] ?? NULL,
+                $this->_params["{$fieldName}_max"] ?? NULL
               );
               if(!empty($clause)){
                 $this->whereClauses[$tableName][] = $clause;
@@ -730,8 +730,8 @@ class CRM_Advancedfundraising_Form_Report_ReportBase extends CRM_Report_Form {
             if (CRM_Utils_Array::value('type', $field) & CRM_Utils_Type::T_DATE
               && !(CRM_Utils_Array::value('operatorType', $field) == self::OP_SINGLEDATE)) {
               if(is_array($field['default'])){
-                $this->_defaults["{$fieldName}_from"] = CRM_Utils_Array::value('from', $field['default']);
-                $this->_defaults["{$fieldName}_to"] = CRM_Utils_Array::value('to', $field['default']);
+                $this->_defaults["{$fieldName}_from"] = $field['default']['from'] ?? NULL;
+                $this->_defaults["{$fieldName}_to"] = $field['default']['to'] ?? NULL;
                 $this->_defaults["{$fieldName}_relative"] = 0;
               }
               else{
@@ -750,7 +750,7 @@ class CRM_Advancedfundraising_Form_Report_ReportBase extends CRM_Report_Form {
           elseif (CRM_Utils_Array::value('operatorType', $field) == CRM_Report_Form::OP_MULTISELECT_SEPARATOR) {
             $this->_defaults["{$fieldName}_op"] = 'mhas';
           }
-          elseif ($op = CRM_Utils_Array::value('default_op', $field)) {
+          elseif ($op = $field['default_op'] ?? NULL) {
             $this->_defaults["{$fieldName}_op"] = $op;
           }
         }
@@ -1403,8 +1403,8 @@ WHERE cg.extends IN ('" . implode("','", $this->_customGroupExtends) . "') AND
   function selectClause(&$tableName, $tableKey, &$fieldName, &$field) {
     if($fieldName == 'phone'){
       $alias = "{$tableName}_{$fieldName}";
-      $this->_columnHeaders["{$tableName}_{$fieldName}"]['title'] = CRM_Utils_Array::value('title', $field);
-      $this->_columnHeaders["{$tableName}_{$fieldName}"]['type'] = CRM_Utils_Array::value('type', $field);
+      $this->_columnHeaders["{$tableName}_{$fieldName}"]['title'] = $field['title'] ?? NULL;
+      $this->_columnHeaders["{$tableName}_{$fieldName}"]['type'] = $field['type'] ?? NULL;
       $this->_selectAliases[] = $alias;
       $this->_columnHeaders['civicrm_tag_tag_name'];
       return " GROUP_CONCAT(CONCAT({$field['dbAlias']},':', phone_civireport.location_type_id) ) as $alias";
@@ -1785,7 +1785,7 @@ WHERE cg.extends IN ('" . implode("','", $extends) . "') AND
     $from = CRM_Report_Utils_Get::getTypedValue("{$fieldName}_from", $type);
     $to = CRM_Report_Utils_Get::getTypedValue("{$fieldName}_to", $type);
 
-    $relative = CRM_Utils_Array::value("{$fieldName}_relative", $_GET);
+    $relative = $_GET["{$fieldName}_relative"] ?? NULL;
     if ($relative) {
       list($from, $to) = CRM_Report_Form::getFromTo($relative, NULL, NULL);
       $from = substr($from, 0, 8);


### PR DESCRIPTION
Replaces deprecated function with equivalent null-coalescing operator. Behavior should be the same before/after.