### PR TITLE
Update deprecated php type casts

### DIFF
--- a/CRM/Advancedfundraising/Form/Report/Contribute/ContributionAggregates.php
+++ b/CRM/Advancedfundraising/Form/Report/Contribute/ContributionAggregates.php
@@ -157,7 +157,7 @@ class CRM_Advancedfundraising_Form_Report_Contribute_ContributionAggregates exte
       $graphData['end_date'][] = $row['to_date'];
       $statusValues = array();
       foreach ($this->_statuses as $status){
-        $statusValues[] = (integer) $row[$status];
+        $statusValues[] = (int) $row[$status];
       }
       $graphData['values'][] = $statusValues;
     }
@@ -186,9 +186,9 @@ class CRM_Advancedfundraising_Form_Report_Contribute_ContributionAggregates exte
       $graphData['end_date'][] = $row['to_date'];
       foreach ($this->_statuses as $status){
         $graphData['value'][] =
-          (integer) $row[$status]
+          (int) $row[$status]
         ;
-        $graphData['values'][$index][$status] = (integer) $row[$status];
+        $graphData['values'][$index][$status] = (int) $row[$status];
       }
     }
 

--- a/CRM/Advancedfundraising/Form/Report/OpenFlashChart.php
+++ b/CRM/Advancedfundraising/Form/Report/OpenFlashChart.php
@@ -276,7 +276,7 @@ class barchart extends chart {
  */
   function setChartValues(){
     foreach ($this->values as $xVal => $yVal) {
-      $this->yValues[] = (double) $yVal[0];
+      $this->yValues[] = (float) $yVal[0];
       $this->xValues[] = (string) $xVal;
     }
     $this->chartElement->set_values($this->yValues);


### PR DESCRIPTION
In PHP 8.5, non-canonical scalar type casts (boolean|double|integer|binary) are deprecated.

See https://php.watch/versions/8.5/boolean-double-integer-binary-casts-deprecated